### PR TITLE
Fixing Alignment Of QR-Image

### DIFF
--- a/src/components/qrGenerator.js
+++ b/src/components/qrGenerator.js
@@ -2,12 +2,11 @@ import React from "react";
 
 const QrGenerator = ({imageUrl}) => {
     return(
-        <div className="container-fluid image mt-5 ms-xl-5">
+        <div className="container-fluid image mt-5 d-flex justify-content-center">
         <img
           src={imageUrl}
           className="img-fluid"
           alt="QR code"
-          style={{ marginLeft: "38%" }}
         ></img>
       </div>
     )


### PR DESCRIPTION
Fixes #1

**Description-**
Added d-flex and justify-content-center classes to make the div flex and center its content
and removed the margin-left style since it's not a good practice to center the item.

**Before-**

![image](https://github.com/1010varun/qr-convertor/assets/140608790/3a274bc3-4ddc-4743-a582-8024d7013158)

**After-**

![image](https://github.com/1010varun/qr-convertor/assets/140608790/5ce46c33-893b-4bcd-a275-ad6f36fe5c10)

