### PR TITLE
Added ability to add images to QR Code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.1.3",
         "bootstrap": "^5.2.2",
-        "file-saver": "^2.0.5",
         "npm": "^10.3.0",
         "react": "^18.2.0",
         "react-color": "^2.19.3",
@@ -10507,11 +10506,6 @@
       "peerDependencies": {
         "webpack": "^4.0.0 || ^5.0.0"
       }
-    },
-    "node_modules/file-saver": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -32474,11 +32468,6 @@
         "loader-utils": "^2.0.0",
         "schema-utils": "^3.0.0"
       }
-    },
-    "file-saver": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
-      "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
     },
     "filelist": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.1.3",
     "bootstrap": "^5.2.2",
-    "file-saver": "^2.0.5",
     "npm": "^10.3.0",
     "react": "^18.2.0",
     "react-color": "^2.19.3",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import "../node_modules/bootstrap/dist/css/bootstrap.min.css";
 
 
@@ -7,7 +7,6 @@ import InputBox from "./components/inputBox";
 import ConvertButton from "./components/ConvertButton";
 import QrGenerator from "./components/qrGenerator";
 import Footer from "./components/Footer";
-import { saveAs } from 'file-saver';
 import './style.css'
 import { SketchPicker } from 'react-color';
 
@@ -16,7 +15,11 @@ const App = () => {
   // const [selectedColor, setSelectedColor] = useState("#000000"); // Default color is black
   const [selectedDownload, setSelectedDownload] = useState("#000000"); // Default color is black
   // const darkTheme = localStorage.getItem("theme");
+  const [logoURL, setLogoURL] = useState("");
 
+  const canvasRef = useRef(null);
+  const logoInput = useRef(null);
+  const downloadRef = useRef(null);
 
   const [currentColor, setCurrentColor] = useState("#000")
   const handleOnChange = (color) => {
@@ -29,6 +32,22 @@ const App = () => {
     setSelectedDownload(qrdownload);
     // console.log("ho", selectedDownload, qrdownload);
   };
+
+  const handleLogoInput = e => {
+    const file = e.target.files[0];
+
+    if (file) {
+      const fr = new FileReader();
+      fr.onload = () => {
+        setLogoURL(fr.result);
+      };
+      fr.readAsDataURL(file);
+    } else {
+      setLogoURL("");
+    }
+  };
+
+
 // console.log(selectedColor)
   useEffect(() => {
     const darkTheme = localStorage.getItem("theme");
@@ -121,7 +140,11 @@ const App = () => {
   // console.log(FileSaver);
 
   const downimage = () => {
-    saveAs(url, "qr." + selectedDownload);
+    const canvas = canvasRef.current;
+    const a = downloadRef.current;
+
+    a.href = canvas.toDataURL(`image/${selectedDownload}`);
+    a.click();
   }
 
   // console.log(darkTheme);
@@ -140,7 +163,7 @@ const App = () => {
           <div className="row">
             <div className="flex">
             <div className="column column1">
-            <QrGenerator imageUrl={url} />
+            <QrGenerator targetURL={url} logoURL={logoURL} canvasRef={canvasRef} />
             </div>
             <div className="column column2">
               <SketchPicker color={currentColor} onChangeComplete={handleOnChange} />
@@ -151,18 +174,23 @@ const App = () => {
                 <label htmlFor="downloadPicker" style={{ color: mode === 'light' ? 'black' : 'white' }}>Download As:</label>
 
                 <select name="cars" id="downloadPicker" onChange={handleDownloadChange}>
-                  <option value="jpg"  defaultValue={"jpg"}>JPG</option>
-                  <option value="png">PNG</option>
+                  <option value="jpeg">JPEG</option>
+                  <option value="png" selected>PNG</option>
                 </select>
                 <b style={{display:'none'}}>Current Download State: <code id="dCode">{selectedDownload}</code></b>
 
               </div>
+
+              <div className="container-fluid" style={{ margin: ".5rem 0" }}>
+                <label htmlFor="logoPicker">Add a Logo: </label>
+                <input id="logoPicker" className="form-control-sm" type="file" accept="image/png, image/jpg, image/jpeg" ref={logoInput} onChange={handleLogoInput} />
+              </div>
+
               <div className="container-fluid">
                 <ConvertButton functionPass={handelClick} />
 
 
-                <button onClick={downimage} className="btn my-btn my-buton mt-3"
-                  style={{ width: "93%" }}>Download</button>
+                <button onClick={downimage} className="btn my-btn my-buton mt-3" style={{ width: "100%" }}>Download</button>
 
 
 </div>
@@ -192,6 +220,7 @@ const App = () => {
 
       </div>
       <Footer />
+      <a href="#null" ref={downloadRef} style={{display: "none"}} download={true}>Download Image</a>
     </>
   );
 };

--- a/src/components/ConvertButton.js
+++ b/src/components/ConvertButton.js
@@ -7,7 +7,7 @@ const ConvertButton = ({functionPass}) => {
       <button
         type="button"
         className="btn buton mt-3"
-        style={{ width: "93%", color: "white" }}
+        style={{ width: "100%", color: "white" }}
         onClick={functionPass}
       >
         Generate QR

--- a/src/components/qrGenerator.js
+++ b/src/components/qrGenerator.js
@@ -1,15 +1,50 @@
-import React from "react";
+import React, { useEffect } from "react";
 
-const QrGenerator = ({imageUrl}) => {
-    return(
-        <div className="container-fluid image mt-3 d-flex justify-content-center">
-        <img
-          src={imageUrl}
-          className="img-fluid"
-          alt="QR code"
-        ></img>
-      </div>
-    )
+const QrGenerator = ({targetURL, logoURL, canvasRef}) => {
+  useEffect(() => {
+    const generateQR = async () => {
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext("2d");
+  
+      let fetchURL = targetURL;
+      if (logoURL !== "") {
+        fetchURL += "&ecc=H";
+      }
+      const res = await fetch(fetchURL);
+      const data = await res.blob();
+  
+      const qr = new Image();
+  
+      qr.onload = () => {
+        ctx.drawImage(qr, 0, 0, 300, 300);
+  
+        if (logoURL !== "") {
+          ctx.fillStyle = "white";
+          ctx.fillRect(102, 102, 96, 96);
+  
+          const logo = new Image();
+  
+          logo.onload = () => {
+            ctx.drawImage(logo, 102, 102, 96, 96);
+          }
+  
+          logo.src = logoURL;
+        }
+      };
+  
+      qr.src = URL.createObjectURL(data);
+    };
+
+    generateQR();
+  }, [targetURL, logoURL, canvasRef]);
+
+  
+
+  return(
+    <div className="container-fluid image mt-3 d-flex justify-content-center">
+      <canvas className="img-fluid" width={300} height={300} ref={canvasRef}></canvas>
+    </div>
+  )
 }
 
 export default QrGenerator;


### PR DESCRIPTION
Fixes #33 

This PR adds the ability to add images to the QR Code. The ECC(Error Correction Code) is set automatically if an image is used.

This PR also removes the dependency `file-saver`, since the QR is manipulated on the client side and it is being downloaded using built-in browser methods, without the need for any dependencies.

I also changed the default value of the download format from `JPEG` to `PNG` since `JPEG`s use lossy compression, which may affect the readability of the QR Code.

https://github.com/1010varun/qr-convertor/assets/56386613/764382cf-8dbd-4fbd-90bc-531b088ca4a7

Any feedback is appreciated.